### PR TITLE
Messages and reactive transactionmanager 

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -23,6 +23,7 @@ Atualização do tipo de Parâmetros no Vquery
 Rota, métodos service e repository isNew, testes
 Criptografia senha no post do UserService
 Alteração do campo password do User para WRITE_ONLY
+Tratamento msg api: QueryException e InvalidDataAccessApiUsageException
 
 1.0. release
 

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -24,6 +24,7 @@ Rota, métodos service e repository isNew, testes
 Criptografia senha no post do UserService
 Alteração do campo password do User para WRITE_ONLY
 Tratamento msg api: QueryException e InvalidDataAccessApiUsageException
+Como não há um TransactionManager adaptável para reactive routes, foi retirado @Transaction para rotas assincronas
 
 1.0. release
 

--- a/api/src/main/java/br/com/munif/framework/vicente/api/BaseAPI.java
+++ b/api/src/main/java/br/com/munif/framework/vicente/api/BaseAPI.java
@@ -53,7 +53,6 @@ public class BaseAPI<T extends BaseEntity> {
         return ResponseEntity.noContent().build();
     }
 
-    @Transactional
     @DeleteMapping(value = "/async/{id}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity<Void>> asyncDelete(@PathVariable String id) {
         return service.asyncMono(delete(id));
@@ -72,7 +71,6 @@ public class BaseAPI<T extends BaseEntity> {
         return new ResponseEntity<>(entity, HttpStatus.CREATED);
     }
 
-    @Transactional
     @PostMapping(value = "/async", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<ResponseEntity<T>> asyncSave(@RequestBody @Valid T model) {
@@ -85,7 +83,6 @@ public class BaseAPI<T extends BaseEntity> {
         return doUpdate(model);
     }
 
-    @Transactional
     @PutMapping(value = "/async", consumes = "application/json", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity<T>> asyncUpdateWithoutId(@RequestBody @Valid T model) {
         return service.asyncMono(doUpdate(model));
@@ -98,7 +95,6 @@ public class BaseAPI<T extends BaseEntity> {
         return doUpdate(model);
     }
 
-    @Transactional
     @PutMapping(value = "/async/{id}", consumes = "application/json", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity<T>> asyncUpdateWithId(@PathVariable("id") String id, @RequestBody @Valid T model) {
         return service.asyncMono(updateWithId(id, model));
@@ -112,7 +108,6 @@ public class BaseAPI<T extends BaseEntity> {
         return ResponseEntity.noContent().build();
     }
 
-    @Transactional
     @PatchMapping(value = "/async/{id}", consumes = "application/json", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity<Void>> asyncPatch(@PathVariable("id") String id, @RequestBody @Valid Map model) {
         return service.asyncMono(patch(id, model));
@@ -125,7 +120,6 @@ public class BaseAPI<T extends BaseEntity> {
         return ResponseEntity.ok(service.patchReturning(model));
     }
 
-    @Transactional
     @PatchMapping(value = "/async/returning/{id}", consumes = "application/json", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity> asyncPatchReturning(@PathVariable("id") String id, @RequestBody @Valid Map model) {
         return service.asyncMono(patchReturning(id, model));
@@ -157,7 +151,6 @@ public class BaseAPI<T extends BaseEntity> {
         return getVicReturnByQuery(query);
     }
 
-    @Transactional
     @GetMapping(value = "/async", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity<VicReturn<T>>> asyncFindHQL(HttpServletRequest request, VicQuery query) {
         return service.asyncMono(findHQL(request, query));
@@ -169,7 +162,6 @@ public class BaseAPI<T extends BaseEntity> {
         return getVicReturnByQuery(query);
     }
 
-    @Transactional
     @PostMapping(value = "/async/vquery", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity<VicReturn<T>>> asyncFindVQuery(@RequestBody VicQuery query) {
         return service.asyncMono(findVQuery(query));
@@ -224,13 +216,11 @@ public class BaseAPI<T extends BaseEntity> {
         return ResponseEntity.ok(service.isNew(id));
     }
 
-    @Transactional
     @GetMapping(value = "/async/is-new/{id}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity> asyncIsNew(@PathVariable String id) {
         return service.asyncMono(isNew(id));
     }
 
-    @Transactional
     @GetMapping(value = "/async/{id}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public Mono<ResponseEntity> asyncLoad(@PathVariable String id, @RequestParam(required = false) String fields) {
         return service.asyncMono(load(id, fields));
@@ -254,7 +244,6 @@ public class BaseAPI<T extends BaseEntity> {
     }
 
     @ResponseBody
-    @Transactional
     @GetMapping(value = "/async/draw/{id}", produces = "image/svg+xml")
     public Mono<ResponseEntity<String>> asyncDraw(@PathVariable String id) {
         return service.asyncMono(draw(id));

--- a/api/src/main/java/br/com/munif/framework/vicente/api/errors/ExceptionTranslator.java
+++ b/api/src/main/java/br/com/munif/framework/vicente/api/errors/ExceptionTranslator.java
@@ -3,11 +3,13 @@ package br.com.munif.framework.vicente.api.errors;
 import br.com.munif.framework.vicente.api.VicenteCreateWithExistingIdException;
 import br.com.munif.framework.vicente.api.VicenteNotFoundException;
 import br.com.munif.framework.vicente.api.VicenteRightsException;
+import org.hibernate.QueryException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -108,6 +110,20 @@ public class ExceptionTranslator {
     @ResponseStatus(HttpStatus.CONFLICT)
     public ErrorVM vicenteCreateWithExistingIdException(VicenteCreateWithExistingIdException exception) {
         return new ErrorVM(ErrorConstants.ERR_CONFLICT, exception.getMessage());
+    }
+
+    @ExceptionHandler(QueryException.class)
+    @ResponseBody
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorVM queryException(QueryException exception) {
+        return new ErrorVM(ErrorConstants.ERR_DATA_INTEGRITY_VIOLATION, exception.getMessage());
+    }
+
+    @ExceptionHandler(InvalidDataAccessApiUsageException.class)
+    @ResponseBody
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorVM invalidDataAccessApiUsageException(InvalidDataAccessApiUsageException exception) {
+        return new ErrorVM(ErrorConstants.ERR_DATA_INTEGRITY_VIOLATION, exception.getMessage());
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
Tratamento msg api: QueryException e InvalidDataAccessApiUsageException
Como não há um TransactionManager adaptável para reactive routes, foi retirado @Transaction para rotas assincronas